### PR TITLE
Add Networking Classes and Helper

### DIFF
--- a/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
+++ b/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
@@ -21,16 +21,20 @@
 		CB9FE6A428F41E2F00A6599C /* MoviesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6A328F41E2F00A6599C /* MoviesListView.swift */; };
 		CB9FE6A728F41EDD00A6599C /* Color+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6A628F41EDD00A6599C /* Color+Extensions.swift */; };
 		CB9FE6AA28F42EC800A6599C /* MovieDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6A928F42EC800A6599C /* MovieDetailView.swift */; };
-		CB9FE6BA28F44DDA00A6599C /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6B928F44DDA00A6599C /* RxCocoa */; };
-		CB9FE6BC28F44DDA00A6599C /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6BB28F44DDA00A6599C /* RxRelay */; };
-		CB9FE6BE28F44DDA00A6599C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6BD28F44DDA00A6599C /* RxSwift */; };
-		CB9FE6C128F44EAF00A6599C /* RxAlamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C028F44EAF00A6599C /* RxAlamofire */; };
-		CB9FE6C428F44F2000A6599C /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C328F44F2000A6599C /* SDWebImageSwiftUI */; };
 		CB9FE6AF28F44A7600A6599C /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6AE28F44A7600A6599C /* URLRequest+Extension.swift */; };
 		CB9FE6B128F44A9500A6599C /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B028F44A9500A6599C /* APIEndpoint.swift */; };
 		CB9FE6B328F44AC200A6599C /* APIMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B228F44AC200A6599C /* APIMethod.swift */; };
 		CB9FE6B528F44B0C00A6599C /* AuthenticationLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */; };
 		CB9FE6B728F44C7900A6599C /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B628F44C7900A6599C /* APIClient.swift */; };
+		CB9FE6BA28F44DDA00A6599C /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6B928F44DDA00A6599C /* RxCocoa */; };
+		CB9FE6BC28F44DDA00A6599C /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6BB28F44DDA00A6599C /* RxRelay */; };
+		CB9FE6BE28F44DDA00A6599C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6BD28F44DDA00A6599C /* RxSwift */; };
+		CB9FE6C128F44EAF00A6599C /* RxAlamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C028F44EAF00A6599C /* RxAlamofire */; };
+		CB9FE6C428F44F2000A6599C /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C328F44F2000A6599C /* SDWebImageSwiftUI */; };
+		CB9FE6C628F4537C00A6599C /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6C528F4537C00A6599C /* NetworkError.swift */; };
+		CB9FE6C828F4543D00A6599C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6C728F4543D00A6599C /* Logger.swift */; };
+		CB9FE6CA28F454C800A6599C /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6C928F454C800A6599C /* ErrorResponse.swift */; };
+		CB9FE6CC28F4552500A6599C /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +78,10 @@
 		CB9FE6B228F44AC200A6599C /* APIMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMethod.swift; sourceTree = "<group>"; };
 		CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationLocalDataSource.swift; sourceTree = "<group>"; };
 		CB9FE6B628F44C7900A6599C /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
+		CB9FE6C528F4537C00A6599C /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		CB9FE6C728F4543D00A6599C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		CB9FE6C928F454C800A6599C /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
+		CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -203,6 +211,10 @@
 				CB9FE6B228F44AC200A6599C /* APIMethod.swift */,
 				CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */,
 				CB9FE6B628F44C7900A6599C /* APIClient.swift */,
+				CB9FE6C928F454C800A6599C /* ErrorResponse.swift */,
+				CB9FE6C528F4537C00A6599C /* NetworkError.swift */,
+				CB9FE6C728F4543D00A6599C /* Logger.swift */,
+				CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -349,6 +361,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CB9FE6CC28F4552500A6599C /* ConnectivityManager.swift in Sources */,
 				CB9FE6A028F417F800A6599C /* WatchedStatusView.swift in Sources */,
 				CB9FE6B728F44C7900A6599C /* APIClient.swift in Sources */,
 				CB9FE6B128F44A9500A6599C /* APIEndpoint.swift in Sources */,
@@ -356,8 +369,11 @@
 				CB9FE69E28F4153600A6599C /* BackButton.swift in Sources */,
 				CB9FE6AA28F42EC800A6599C /* MovieDetailView.swift in Sources */,
 				CB9FE6B328F44AC200A6599C /* APIMethod.swift in Sources */,
+				CB9FE6CA28F454C800A6599C /* ErrorResponse.swift in Sources */,
+				CB9FE6C828F4543D00A6599C /* Logger.swift in Sources */,
 				CB9FE6A728F41EDD00A6599C /* Color+Extensions.swift in Sources */,
 				CB9FE6A228F4188200A6599C /* FavouriteStatusView.swift in Sources */,
+				CB9FE6C628F4537C00A6599C /* NetworkError.swift in Sources */,
 				CB9FE67228F36C4B00A6599C /* ContentView.swift in Sources */,
 				CB9FE69B28F40EBC00A6599C /* MovieRowView.swift in Sources */,
 				CB9FE6B528F44B0C00A6599C /* AuthenticationLocalDataSource.swift in Sources */,

--- a/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
+++ b/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
@@ -26,6 +26,11 @@
 		CB9FE6BE28F44DDA00A6599C /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6BD28F44DDA00A6599C /* RxSwift */; };
 		CB9FE6C128F44EAF00A6599C /* RxAlamofire in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C028F44EAF00A6599C /* RxAlamofire */; };
 		CB9FE6C428F44F2000A6599C /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = CB9FE6C328F44F2000A6599C /* SDWebImageSwiftUI */; };
+		CB9FE6AF28F44A7600A6599C /* URLRequest+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6AE28F44A7600A6599C /* URLRequest+Extension.swift */; };
+		CB9FE6B128F44A9500A6599C /* APIEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B028F44A9500A6599C /* APIEndpoint.swift */; };
+		CB9FE6B328F44AC200A6599C /* APIMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B228F44AC200A6599C /* APIMethod.swift */; };
+		CB9FE6B528F44B0C00A6599C /* AuthenticationLocalDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */; };
+		CB9FE6B728F44C7900A6599C /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6B628F44C7900A6599C /* APIClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -64,6 +69,11 @@
 		CB9FE6A628F41EDD00A6599C /* Color+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extensions.swift"; sourceTree = "<group>"; };
 		CB9FE6A828F42E5700A6599C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		CB9FE6A928F42EC800A6599C /* MovieDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieDetailView.swift; sourceTree = "<group>"; };
+		CB9FE6AE28F44A7600A6599C /* URLRequest+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLRequest+Extension.swift"; sourceTree = "<group>"; };
+		CB9FE6B028F44A9500A6599C /* APIEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoint.swift; sourceTree = "<group>"; };
+		CB9FE6B228F44AC200A6599C /* APIMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIMethod.swift; sourceTree = "<group>"; };
+		CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationLocalDataSource.swift; sourceTree = "<group>"; };
+		CB9FE6B628F44C7900A6599C /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +132,7 @@
 				CB9FE6A828F42E5700A6599C /* Info.plist */,
 				CB9FE66F28F36C4B00A6599C /* TheMovieAppApp.swift */,
 				CB9FE67128F36C4B00A6599C /* ContentView.swift */,
+				CB9FE6AB28F44A0A00A6599C /* Networking */,
 				CB9FE6A528F41ED000A6599C /* Extensions */,
 				CB9FE69928F40DE000A6599C /* Views */,
 				CB9FE67328F36C4D00A6599C /* Assets.xcassets */,
@@ -180,8 +191,20 @@
 			isa = PBXGroup;
 			children = (
 				CB9FE6A628F41EDD00A6599C /* Color+Extensions.swift */,
+				CB9FE6AE28F44A7600A6599C /* URLRequest+Extension.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		CB9FE6AB28F44A0A00A6599C /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				CB9FE6B028F44A9500A6599C /* APIEndpoint.swift */,
+				CB9FE6B228F44AC200A6599C /* APIMethod.swift */,
+				CB9FE6B428F44B0C00A6599C /* AuthenticationLocalDataSource.swift */,
+				CB9FE6B628F44C7900A6599C /* APIClient.swift */,
+			);
+			path = Networking;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -327,14 +350,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB9FE6A028F417F800A6599C /* WatchedStatusView.swift in Sources */,
+				CB9FE6B728F44C7900A6599C /* APIClient.swift in Sources */,
+				CB9FE6B128F44A9500A6599C /* APIEndpoint.swift in Sources */,
 				CB9FE6A428F41E2F00A6599C /* MoviesListView.swift in Sources */,
 				CB9FE69E28F4153600A6599C /* BackButton.swift in Sources */,
 				CB9FE6AA28F42EC800A6599C /* MovieDetailView.swift in Sources */,
+				CB9FE6B328F44AC200A6599C /* APIMethod.swift in Sources */,
 				CB9FE6A728F41EDD00A6599C /* Color+Extensions.swift in Sources */,
 				CB9FE6A228F4188200A6599C /* FavouriteStatusView.swift in Sources */,
 				CB9FE67228F36C4B00A6599C /* ContentView.swift in Sources */,
 				CB9FE69B28F40EBC00A6599C /* MovieRowView.swift in Sources */,
+				CB9FE6B528F44B0C00A6599C /* AuthenticationLocalDataSource.swift in Sources */,
 				CB9FE67028F36C4B00A6599C /* TheMovieAppApp.swift in Sources */,
+				CB9FE6AF28F44A7600A6599C /* URLRequest+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
+++ b/TheMovieApp/TheMovieApp.xcodeproj/project.pbxproj
@@ -35,6 +35,12 @@
 		CB9FE6C828F4543D00A6599C /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6C728F4543D00A6599C /* Logger.swift */; };
 		CB9FE6CA28F454C800A6599C /* ErrorResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6C928F454C800A6599C /* ErrorResponse.swift */; };
 		CB9FE6CC28F4552500A6599C /* ConnectivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */; };
+		CB9FE6CF28F4560C00A6599C /* BaseRemoteDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6CE28F4560C00A6599C /* BaseRemoteDataSource.swift */; };
+		CB9FE6D228F4583100A6599C /* MoviesRemoteDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6D128F4583100A6599C /* MoviesRemoteDataSource.swift */; };
+		CB9FE6D528F4586300A6599C /* MoviesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6D428F4586300A6599C /* MoviesResponse.swift */; };
+		CB9FE6D728F458DE00A6599C /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6D628F458DE00A6599C /* Movie.swift */; };
+		CB9FE6DA28F4591F00A6599C /* MoviesUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6D928F4591F00A6599C /* MoviesUseCase.swift */; };
+		CB9FE6DC28F4592B00A6599C /* MoviesUseCaseProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9FE6DB28F4592B00A6599C /* MoviesUseCaseProtocol.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -82,6 +88,12 @@
 		CB9FE6C728F4543D00A6599C /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		CB9FE6C928F454C800A6599C /* ErrorResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorResponse.swift; sourceTree = "<group>"; };
 		CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityManager.swift; sourceTree = "<group>"; };
+		CB9FE6CE28F4560C00A6599C /* BaseRemoteDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRemoteDataSource.swift; sourceTree = "<group>"; };
+		CB9FE6D128F4583100A6599C /* MoviesRemoteDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesRemoteDataSource.swift; sourceTree = "<group>"; };
+		CB9FE6D428F4586300A6599C /* MoviesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesResponse.swift; sourceTree = "<group>"; };
+		CB9FE6D628F458DE00A6599C /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
+		CB9FE6D928F4591F00A6599C /* MoviesUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesUseCase.swift; sourceTree = "<group>"; };
+		CB9FE6DB28F4592B00A6599C /* MoviesUseCaseProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesUseCaseProtocol.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +152,9 @@
 				CB9FE6A828F42E5700A6599C /* Info.plist */,
 				CB9FE66F28F36C4B00A6599C /* TheMovieAppApp.swift */,
 				CB9FE67128F36C4B00A6599C /* ContentView.swift */,
+				CB9FE6D828F4590A00A6599C /* Use Cases */,
+				CB9FE6D328F4585900A6599C /* Model */,
+				CB9FE6D028F4582700A6599C /* DataSource */,
 				CB9FE6AB28F44A0A00A6599C /* Networking */,
 				CB9FE6A528F41ED000A6599C /* Extensions */,
 				CB9FE69928F40DE000A6599C /* Views */,
@@ -215,8 +230,43 @@
 				CB9FE6C528F4537C00A6599C /* NetworkError.swift */,
 				CB9FE6C728F4543D00A6599C /* Logger.swift */,
 				CB9FE6CB28F4552500A6599C /* ConnectivityManager.swift */,
+				CB9FE6CD28F4560000A6599C /* Generics */,
 			);
 			path = Networking;
+			sourceTree = "<group>";
+		};
+		CB9FE6CD28F4560000A6599C /* Generics */ = {
+			isa = PBXGroup;
+			children = (
+				CB9FE6CE28F4560C00A6599C /* BaseRemoteDataSource.swift */,
+			);
+			path = Generics;
+			sourceTree = "<group>";
+		};
+		CB9FE6D028F4582700A6599C /* DataSource */ = {
+			isa = PBXGroup;
+			children = (
+				CB9FE6D128F4583100A6599C /* MoviesRemoteDataSource.swift */,
+			);
+			path = DataSource;
+			sourceTree = "<group>";
+		};
+		CB9FE6D328F4585900A6599C /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CB9FE6D428F4586300A6599C /* MoviesResponse.swift */,
+				CB9FE6D628F458DE00A6599C /* Movie.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		CB9FE6D828F4590A00A6599C /* Use Cases */ = {
+			isa = PBXGroup;
+			children = (
+				CB9FE6DB28F4592B00A6599C /* MoviesUseCaseProtocol.swift */,
+				CB9FE6D928F4591F00A6599C /* MoviesUseCase.swift */,
+			);
+			path = "Use Cases";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -362,6 +412,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CB9FE6CC28F4552500A6599C /* ConnectivityManager.swift in Sources */,
+				CB9FE6D228F4583100A6599C /* MoviesRemoteDataSource.swift in Sources */,
 				CB9FE6A028F417F800A6599C /* WatchedStatusView.swift in Sources */,
 				CB9FE6B728F44C7900A6599C /* APIClient.swift in Sources */,
 				CB9FE6B128F44A9500A6599C /* APIEndpoint.swift in Sources */,
@@ -375,9 +426,14 @@
 				CB9FE6A228F4188200A6599C /* FavouriteStatusView.swift in Sources */,
 				CB9FE6C628F4537C00A6599C /* NetworkError.swift in Sources */,
 				CB9FE67228F36C4B00A6599C /* ContentView.swift in Sources */,
+				CB9FE6CF28F4560C00A6599C /* BaseRemoteDataSource.swift in Sources */,
 				CB9FE69B28F40EBC00A6599C /* MovieRowView.swift in Sources */,
+				CB9FE6D528F4586300A6599C /* MoviesResponse.swift in Sources */,
 				CB9FE6B528F44B0C00A6599C /* AuthenticationLocalDataSource.swift in Sources */,
+				CB9FE6DA28F4591F00A6599C /* MoviesUseCase.swift in Sources */,
+				CB9FE6DC28F4592B00A6599C /* MoviesUseCaseProtocol.swift in Sources */,
 				CB9FE67028F36C4B00A6599C /* TheMovieAppApp.swift in Sources */,
+				CB9FE6D728F458DE00A6599C /* Movie.swift in Sources */,
 				CB9FE6AF28F44A7600A6599C /* URLRequest+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/TheMovieApp/TheMovieApp/DataSource/MoviesRemoteDataSource.swift
+++ b/TheMovieApp/TheMovieApp/DataSource/MoviesRemoteDataSource.swift
@@ -1,0 +1,105 @@
+//
+//  MoviesRemoteDataSource.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+import RxSwift
+
+final class MoviesRemoteDataSource: BaseRemoteDataSource {
+    func getTopRatedMovies(using filter: MoviesFilter) -> Single<MoviesResponse> {
+        requestMovies(filter).map({ $0.0 })
+    }
+
+    func getSimilarMovies() -> Single<MoviesResponse> {
+        requestSimilarMovies().map({ $0.0 })
+    }
+
+    func getMovieDetail(_ movieID: String) -> Single<Movie> {
+        requestMovieDetail().map({ $0.0 })
+    }
+
+}
+
+private extension MoviesRemoteDataSource {
+    func requestMovies(_ filter: MoviesFilter) -> Single<(MoviesResponse, HTTPURLResponse)> {
+        let params = filter.getParameters()
+        let urlRequest = URLRequest(.topRated, .get, params)
+        return apiRequest(urlRequest)
+    }
+
+
+    func requestSimilarMovies() -> Single<(MoviesResponse, HTTPURLResponse)> {
+        let urlRequest = URLRequest(.similar, .get)
+        return apiRequest(urlRequest)
+    }
+
+    func requestMovieDetail() -> Single<(Movie, HTTPURLResponse)> {
+        let urlRequest = URLRequest(.detail, .get)
+        return apiRequest(urlRequest)
+    }
+}
+
+struct MoviesFilter {
+    var limit: Int? // between 1 - 50 (inclusive) The limit of results per page that has been set
+    var page: Int? // 1Used to see the next page of movies, eg limit=15 and page=2 will show you movies 15-30
+//    var quality: TorrentQuality? // (720p, 1080p, 2160p, 3D)    All    Used to filter by a given quality
+
+    var minimum_rating: Int? // between 0 - 9 (inclusive)    0    Used to filter movie by a given minimum IMDb ratinga
+    var query_term: String? //  0    Used for movie search, matching on: Movie Title/IMDb Code, Actor Name/IMDb Code, Director Name/IMDb Code
+    var genre: Genre? // Used to filter by a given genre (See http://www.imdb.com/genre/ for full list)
+
+    var sort_by: SortBy? // Sorts the results by choosen value
+    var order_by: Order? //  Orders the results by either Ascending or Descending order
+    var with_rt_ratings: Bool? = false // Returns the list with the Rotten Tomatoes rating included
+
+    func getParameters() -> [String: Any] {
+        var params = [String: Any]()
+
+        if let limit { params["limit"] = limit }
+        if let page { params["page"] = page }
+//        if let quality { params["quality"] = quality.rawValue }
+
+        if let minimum_rating { params["minimum_rating"] = minimum_rating }
+        if let query_term { params["query_term"] = query_term }
+        if let genre { params["genre"] = genre.rawValue }
+
+        if let sort_by { params["sort_by"] = sort_by.rawValue }
+        if let order_by { params["order_by"] = order_by.rawValue }
+        if let with_rt_ratings { params["with_rt_ratings"] = with_rt_ratings }
+
+        return params
+    }
+}
+
+extension MoviesFilter {
+    enum Genre: String {
+        case all = "All"
+        case comedy
+        case scifi = "sci-fi"
+        case horror
+        case romance
+        case action
+        case thriller
+        case drama
+        case mystery
+        case crime
+        case animation
+        case adventure
+        case fantasy
+        case comedyRomance = "comedy-romance"
+        case actionComedy = "action-comedy"
+        case superhero
+    }
+
+    enum Order: String {
+        case ascending = "asc"
+        case descending = "desc"
+    }
+
+    enum SortBy: String {
+        case title, year, rating, peers, seeds, download_count, like_count, date_added
+    }
+}

--- a/TheMovieApp/TheMovieApp/Extensions/URLRequest+Extension.swift
+++ b/TheMovieApp/TheMovieApp/Extensions/URLRequest+Extension.swift
@@ -1,0 +1,81 @@
+//
+//  URLRequest+Extension.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+extension URLRequest {
+    private static let moviesDBBaseUrl = "https://api.themoviedb.org/3/movie"
+
+    init(_ endpoint: APIEndpoint, _ method: APIMethod, _ parameters: [String: Any?]? = nil, customHeaders: [String: String] = [:], _ urlArgs: CVarArg...) {
+
+        let path = String(format: endpoint.rawValue, arguments: urlArgs)
+        let urlString = URLRequest.urlResolver(for: endpoint, path: path)
+        let url = URL(string: urlString)!
+        self.init(url: url)
+        httpMethod = method.rawValue
+        processParameters(method, parameters)
+        self.addValue("application/json", forHTTPHeaderField: "Accept")
+        self.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        self.addValue("passenger", forHTTPHeaderField: "App-Type")
+
+        for (key, value) in customHeaders {
+            self.addValue(value, forHTTPHeaderField: key)
+        }
+
+        if let accessToken = AuthenticationLocalDataSource.getAccessToken() {
+            addValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
+            print("🏀 accessToken \(accessToken)")
+        }
+
+        timeoutInterval = 30
+
+        print("🚀 \(String(describing: parameters))")
+        print("🏀 url \(url)")
+    }
+
+    private static func urlResolver(for endPoint: APIEndpoint, path: String) -> String {
+        switch endPoint.baseURL {
+        case .moviesDB_url:
+            return "\(URLRequest.moviesDBBaseUrl)\(path)"
+        }
+    }
+
+    private mutating func processParameters(_ method: APIMethod, _ parameters: [String: Any?]? = nil) {
+        switch method {
+        case .get:
+            processGetParameters(parameters)
+        default:
+            processPostParameters(parameters)
+        }
+    }
+
+    private mutating func processPostParameters(_ parameters: [String: Any?]? = nil) {
+        if let parameters = parameters, let jsonParameters = try? JSONSerialization.data(withJSONObject: parameters,
+                                                                                         options: []) {
+            self.httpBody = jsonParameters
+        }
+    }
+
+    private mutating func processGetParameters(_ parameters: [String: Any?]? = nil) {
+        guard let parameters = parameters, !parameters.isEmpty else { return }
+        let queryParameters = parameters.reduce("?") { (result, element) -> String in
+            guard let value = element.value else { return result }
+            guard value as? String != "" else { return result }
+            if result.count > 1 {
+                return "\(result)&\(element.key)=\(value)"
+            }
+            return "\(result)\(element.key)=\(value)"
+        }
+        var queryCharSet = NSCharacterSet.urlQueryAllowed
+        queryCharSet.remove(charactersIn: "+")
+        if let url = self.url?.absoluteString,
+           let urlQueryParameters = queryParameters.addingPercentEncoding(withAllowedCharacters: queryCharSet) {
+            let urlWithParameters = "\(url)\(urlQueryParameters)"
+            self.url = URL(string: urlWithParameters)!
+        }
+    }
+}

--- a/TheMovieApp/TheMovieApp/Model/Movie.swift
+++ b/TheMovieApp/TheMovieApp/Model/Movie.swift
@@ -1,0 +1,10 @@
+//
+//  Movie.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+struct Movie: Codable {}

--- a/TheMovieApp/TheMovieApp/Model/MoviesResponse.swift
+++ b/TheMovieApp/TheMovieApp/Model/MoviesResponse.swift
@@ -1,0 +1,12 @@
+//
+//  MoviesResponse.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+struct MoviesResponse: Codable {
+    
+}

--- a/TheMovieApp/TheMovieApp/Networking/APIClient.swift
+++ b/TheMovieApp/TheMovieApp/Networking/APIClient.swift
@@ -6,3 +6,131 @@
 //
 
 import Foundation
+import RxSwift
+import Alamofire
+import RxAlamofire
+
+public class APIClient {
+    private var sessionManager: Session
+#if DEBUG
+    let log: Logger = Logger()
+#endif
+
+    public init() {
+        sessionManager = Session()
+    }
+
+    func request<T: Decodable>(_ urlRequest: URLRequest) -> Single<(T, HTTPURLResponse)> {
+        return Single.create(subscribe: { [unowned self] (observer) -> Disposable in
+            if ConnectivityManager().isConnected() {
+                return self.request(urlRequest, { (response, urlResponse) in
+                    observer(.success((response, urlResponse)))
+                }, { (error) in
+                    observer(.failure(error))
+                })
+            } else {
+                observer(.failure(APIError.internetConnection))
+                return Disposables.create()
+            }
+        })
+    }
+
+    func request(_ urlRequest: URLRequest) -> Single<(HTTPURLResponse)> {
+        return Single.create(subscribe: { [unowned self] (observer) -> Disposable in
+            if ConnectivityManager().isConnected() {
+                return self.request(urlRequest, { (urlResponse) in
+                    observer(.success((urlResponse)))
+                }, { (error) in
+                    observer(.failure(error))
+                })
+            } else {
+                observer(.failure(APIError.internetConnection))
+                return Disposables.create()
+            }
+        })
+    }
+
+    private func request<T: Decodable>(_ urlRequest: URLRequest,
+                                       _ responseHandler: @escaping (T, HTTPURLResponse) -> Void,
+                                       _ errorHandler: @escaping ((_ error: APIError) -> Void)) -> Disposable {
+        let disposableResponse = sessionManager
+            .rx
+            .request(urlRequest: urlRequest)
+            .responseJSON()
+            .asSingle()
+            .timeout(RxTimeInterval.seconds(30), scheduler: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] (response) in
+                guard let self = self else { return }
+                guard let httpUrlResponse = response.response else {
+                    return
+                }
+                let statusCode = httpUrlResponse.statusCode
+                if 200..<300 ~= statusCode {
+                    self.decodeResponse(response, responseHandler)
+                } else {
+                    guard let data = response.data else { return }
+                    self.decode(data, statusCode: statusCode, errorHandler)
+                }
+            }, onFailure: { _ in
+                errorHandler(.timeout)
+            })
+        return disposableResponse
+    }
+
+    private func request(_ urlRequest: URLRequest,
+                         _ responseHandler: @escaping (HTTPURLResponse) -> Void,
+                         _ errorHandler: @escaping ((_ error: APIError) -> Void)) -> Disposable {
+        let disposableResponse = sessionManager
+            .rx
+            .request(urlRequest: urlRequest)
+            .responseData()
+            .asSingle()
+            .timeout(RxTimeInterval.seconds(30), scheduler: MainScheduler.instance)
+            .subscribe(onSuccess: { [weak self] (httpUrlResponse, data) in
+                if 200..<300 ~= httpUrlResponse.statusCode {
+                    responseHandler(httpUrlResponse)
+                } else {
+                    guard let self = self else { return }
+                    self.logError(urlRequest, response: httpUrlResponse)
+                    self.decode(data, statusCode: httpUrlResponse.statusCode, errorHandler)
+                }
+            }, onFailure: { _ in
+                errorHandler(.timeout)
+            })
+        return disposableResponse
+    }
+
+    private func decode(_ data: Data, statusCode: Int, _ errorHandler: ((_ error: APIError) -> Void)) {
+        do {
+            let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: data)
+            errorHandler(APIError.apiError(code: statusCode,
+                                           message: errorResponse.message ?? ""))
+        } catch {
+            errorHandler(.unableToDecodeData)
+        }
+    }
+
+    private func decodeResponse<T: Decodable>(_ response: DataResponse<Any, AFError>,
+                                              _ responseHandler: @escaping (T, HTTPURLResponse) -> Void) {
+        if let jsonData = response.data, let httpUrlResponse = response.response {
+            if let jsonObject = try? JSONSerialization.jsonObject(with: jsonData, options: []) {
+                print("The Json is", jsonObject)
+            }
+            do {
+                let decoder = JSONDecoder()
+                decoder.dateDecodingStrategy = .iso8601
+                responseHandler(try decoder.decode(T.self, from: jsonData), httpUrlResponse)
+            } catch let error {
+                print("Decoding error: \(error), \(T.self)")
+            }
+        }
+    }
+
+    func logError(_ urlRequest: URLRequest, response: HTTPURLResponse) {
+        #if DEBUG
+        log.error(urlRequest)
+        log.error(urlRequest.allHTTPHeaderFields ?? [:])
+        log.error(response)
+        #endif
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/APIClient.swift
+++ b/TheMovieApp/TheMovieApp/Networking/APIClient.swift
@@ -1,0 +1,8 @@
+//
+//  APIClient.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation

--- a/TheMovieApp/TheMovieApp/Networking/APIEndpoint.swift
+++ b/TheMovieApp/TheMovieApp/Networking/APIEndpoint.swift
@@ -1,0 +1,20 @@
+//
+//  APIEndpoint.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+enum APIEndpoint: String {
+    case topRated = "top_rated"
+
+    var baseURL: BaseURL {
+        return .moviesDB_url
+    }
+    enum BaseURL {
+        case moviesDB_url
+
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/APIEndpoint.swift
+++ b/TheMovieApp/TheMovieApp/Networking/APIEndpoint.swift
@@ -9,6 +9,8 @@ import Foundation
 
 enum APIEndpoint: String {
     case topRated = "top_rated"
+    case similar = "similar"
+    case detail = "detail"
 
     var baseURL: BaseURL {
         return .moviesDB_url

--- a/TheMovieApp/TheMovieApp/Networking/APIMethod.swift
+++ b/TheMovieApp/TheMovieApp/Networking/APIMethod.swift
@@ -1,0 +1,15 @@
+//
+//  APIMethod.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+enum APIMethod: String {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case patch = "PATCH"
+}

--- a/TheMovieApp/TheMovieApp/Networking/AuthenticationLocalDataSource.swift
+++ b/TheMovieApp/TheMovieApp/Networking/AuthenticationLocalDataSource.swift
@@ -1,0 +1,14 @@
+//
+//  AuthenticationLocalDataSource.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+enum AuthenticationLocalDataSource {
+    static func getAccessToken() -> String? {
+        return ""
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/ConnectivityManager.swift
+++ b/TheMovieApp/TheMovieApp/Networking/ConnectivityManager.swift
@@ -1,0 +1,31 @@
+//
+//  ConnectivityManager.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Network
+
+public class ConnectivityManager {
+    private let monitor = NWPathMonitor()
+    public static let shared = ConnectivityManager()
+    private var connected: Bool
+
+    public init() {
+        self.connected = true
+        monitor.pathUpdateHandler = { path in
+            if path.status == .satisfied {
+                self.connected = true
+            } else {
+                self.connected = false
+            }
+        }
+        let queue = DispatchQueue(label: "Monitor")
+        monitor.start(queue: queue)
+    }
+
+    public func isConnected() -> Bool {
+        return self.connected
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/ErrorResponse.swift
+++ b/TheMovieApp/TheMovieApp/Networking/ErrorResponse.swift
@@ -1,0 +1,18 @@
+//
+//  ErrorResponse.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+public struct ErrorResponse: Codable {
+    public let status: String
+    public let message: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case status
+        case message = "status_message"
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/Generics/BaseRemoteDataSource.swift
+++ b/TheMovieApp/TheMovieApp/Networking/Generics/BaseRemoteDataSource.swift
@@ -1,0 +1,81 @@
+//
+//  BaseRemoteDataSource.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+import RxSwift
+
+class BaseRemoteDataSource {
+    private let api: APIClient
+    init() {
+        api = APIClient()
+    }
+
+    func apiRequest<T: Codable>(_ urlRequest: URLRequest, isSecondTryAfterAuth: Bool = false) -> Single<(T, HTTPURLResponse)> {
+        return api.request(urlRequest).catch({ [unowned self] error in
+            if let movieError = getInternalError(error) {
+                switch movieError {
+                case .unauthorized:
+                    return Single.error(movieError)
+                default:
+                    return Single.error(error)
+                }
+            } else {
+                return Single.create(subscribe: { [unowned self] single -> Disposable in
+                    if let pmError = parseError(error) {
+                        single(.failure(pmError))
+                    } else {
+                        single(.failure(error))
+                    }
+                    return Disposables.create()
+                })
+            }
+        })
+    }
+
+    func apiRequest(_ urlRequest: URLRequest, isSecondTryAfterAuth: Bool = false) -> Single<HTTPURLResponse> {
+        return api.request(urlRequest).catch({ [unowned self] error in
+
+            if let movieError = getInternalError(error) {
+                switch movieError {
+                case .unauthorized:
+                    return Single.error(movieError)
+                default:
+                    return Single.error(error)
+                }
+
+            } else {
+                return singleError(error: error)
+            }
+        })
+    }
+
+    private func parseError(_ error: Error) -> APIError? {
+        return getInternalError(error)
+    }
+
+    private func getInternalError(_ error: Error) -> APIError? {
+        if case let APIError.apiError(code, _) = error {
+            if code == 406 || code == 401 {
+                return .unauthorized
+            } else if code == 403 {
+                return APIError.dataBaseError
+            }
+        }
+        return nil
+    }
+
+    private func singleError(error: Error) -> Single<HTTPURLResponse> {
+        return Single.create(subscribe: { [unowned self] single -> Disposable in
+            if let sbError = parseError(error) {
+                single(.failure(sbError))
+            } else {
+                single(.failure(error))
+            }
+            return Disposables.create()
+        })
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/Logger.swift
+++ b/TheMovieApp/TheMovieApp/Networking/Logger.swift
@@ -1,0 +1,19 @@
+//
+//  Logger.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+open class Logger {
+    /// The queue used for logging.
+    private let queue = DispatchQueue(label: "themovie.alpha.log")
+
+    func error(_ log: Any, terminator: String = "\n", file: String = #file, line: Int = #line, column: Int = #column, function: String = #function) {
+        queue.async {
+            Swift.print(log, function, file, line, column)
+        }
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/NetworkError.swift
+++ b/TheMovieApp/TheMovieApp/Networking/NetworkError.swift
@@ -1,0 +1,45 @@
+//
+//  NetworkError.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+
+typealias APIError = NetworkError
+public enum NetworkError: Error {
+    case invalidUrl
+    case invalidResponse
+    case invalidData
+    case unableToDecodeData
+    case unableToEncodeData
+    case unknownError(message: String)
+    case apiError(code: Int, message: String)
+    case serverError
+    case internetConnection
+    case timeout
+
+    public var message: String {
+        switch self {
+        case .invalidUrl:
+            return "Invalid url"
+        case .invalidResponse:
+            return "The response found is not valid"
+        case .unableToDecodeData:
+            return "We could not process the result."
+        case .unableToEncodeData:
+            return "Unable to encode the entered data."
+        case .unknownError(let message):
+            return message
+        case .serverError:
+            return "There is an error on the server."
+        case .internetConnection, .timeout:
+            return "Check your internet connection and try again."
+        case .invalidData:
+            return "Unknown error encountered."
+        case .apiError(_, let message):
+            return message
+        }
+    }
+}

--- a/TheMovieApp/TheMovieApp/Networking/NetworkError.swift
+++ b/TheMovieApp/TheMovieApp/Networking/NetworkError.swift
@@ -10,8 +10,6 @@ import Foundation
 typealias APIError = NetworkError
 public enum NetworkError: Error {
     case invalidUrl
-    case invalidResponse
-    case invalidData
     case unableToDecodeData
     case unableToEncodeData
     case unknownError(message: String)
@@ -19,13 +17,13 @@ public enum NetworkError: Error {
     case serverError
     case internetConnection
     case timeout
+    case unauthorized
+    case dataBaseError
 
     public var message: String {
         switch self {
         case .invalidUrl:
             return "Invalid url"
-        case .invalidResponse:
-            return "The response found is not valid"
         case .unableToDecodeData:
             return "We could not process the result."
         case .unableToEncodeData:
@@ -36,8 +34,10 @@ public enum NetworkError: Error {
             return "There is an error on the server."
         case .internetConnection, .timeout:
             return "Check your internet connection and try again."
-        case .invalidData:
+        case .dataBaseError:
             return "Unknown error encountered."
+        case .unauthorized:
+            return "An error was encountered, try again later"
         case .apiError(_, let message):
             return message
         }

--- a/TheMovieApp/TheMovieApp/Use Cases/MoviesUseCase.swift
+++ b/TheMovieApp/TheMovieApp/Use Cases/MoviesUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  MoviesUseCase.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+import RxSwift
+
+final class MoviesUseCase: MoviesUseCaseProtocol {
+
+    private let dataSource: MoviesRemoteDataSource
+
+    init() {
+        self.dataSource = MoviesRemoteDataSource()
+    }
+
+    func getTopRatedMovies(using filter: MoviesFilter) -> RxSwift.Single<MoviesResponse> {
+        dataSource.getTopRatedMovies(using: filter)
+    }
+
+    func getSimilarMovies() -> RxSwift.Single<MoviesResponse> {
+        dataSource.getSimilarMovies()
+    }
+
+    func getMovieDetail(_ movieID: String) -> Single<Movie> {
+        dataSource.getMovieDetail(movieID)
+    }
+
+
+}

--- a/TheMovieApp/TheMovieApp/Use Cases/MoviesUseCaseProtocol.swift
+++ b/TheMovieApp/TheMovieApp/Use Cases/MoviesUseCaseProtocol.swift
@@ -1,0 +1,15 @@
+//
+//  MoviesUseCaseProtocol.swift
+//  TheMovieApp
+//
+//  Created by Cédric Bahirwe on 10/10/2022.
+//
+
+import Foundation
+import RxSwift
+
+protocol MoviesUseCaseProtocol {
+    func getTopRatedMovies(using filter: MoviesFilter) -> Single<MoviesResponse>
+    func getSimilarMovies() -> Single<MoviesResponse>
+    func getMovieDetail(_ movieID: String) -> Single<Movie>
+}


### PR DESCRIPTION
Added:
- APIClient: main generic networking class built on top of Alamofire and RxSwift 
- APIEndpoint: placeholder for used movies endpoints
- APIMethod: HTTP methods in RESTful API form
- ConnectivityManager: proof of concept class to allow checking for connectivity before doing any HTTP request
- BaseRemoteDataSource: encapsulator of `APIClient`, is used as a parent class for children classes to access the APIClient